### PR TITLE
fix(installer): create the service group and stop hiding useradd errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -709,10 +709,23 @@ log_proxy_status
 
 log_step 1 "Service User"
 
+# useradd --gid requires the group to exist already, and only the
+# openvox-server / openvoxdb packages create 'puppet'. A dedicated console
+# (agent package only) or a non-default SERVICE_GROUP has no such group,
+# so create it here. Errors are not discarded: under set -e a failed
+# useradd aborts now with its real message instead of surfacing four
+# steps later as "chown: invalid user".
+if getent group "$SERVICE_GROUP" >/dev/null; then
+    log_ok "Group '${SERVICE_GROUP}' already exists"
+else
+    groupadd --system "$SERVICE_GROUP"
+    log_ok "Created system group '${SERVICE_GROUP}'"
+fi
+
 if id "$SERVICE_USER" &>/dev/null; then
     log_ok "User '${SERVICE_USER}' already exists"
 else
-    useradd --system --gid "$SERVICE_GROUP" --shell /sbin/nologin --home-dir "$INSTALL_DIR" "$SERVICE_USER" 2>/dev/null || true
+    useradd --system --gid "$SERVICE_GROUP" --shell /sbin/nologin --home-dir "$INSTALL_DIR" "$SERVICE_USER"
     log_ok "Created system user '${SERVICE_USER}'"
 fi
 


### PR DESCRIPTION
Step 1 runs `useradd --gid "$SERVICE_GROUP" … 2>/dev/null || true` and prints "Created system user" regardless. `useradd --gid` needs the group to exist, and only the openvox-server/openvoxdb packages create `puppet`, so on a dedicated console or with a non-default `SERVICE_GROUP` the user is never created and the install dies four steps later at `chown: invalid user`.

Create the group with `groupadd --system` when it's missing and drop the `2>/dev/null || true` so a failed `useradd` aborts under `set -e` with its real error. Checked in almalinux:10 and ubuntu:24.04 containers: fresh host creates group and user, a re-run reports both as existing, a custom user/group works, and an invalid name now fails immediately with useradd's message.

Closes #45.

Assisted by: Claude Code