### PR TITLE
ci: install-test install.sh in systemd containers on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+# Install test: run install.sh end to end on the supported platforms.
+#
+# The frontend is built once and shared; each matrix leg starts a systemd
+# container, runs the unattended installer with BUILD_FRONTEND=false, and
+# checks the service, /health and the admin login. See
+# scripts/ci-install-test.sh (same script works locally).
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build
+        run: cd frontend && npm ci --no-audit --no-fund && npm run build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          if-no-files-found: error
+
+  install-test:
+    name: install.sh ${{ matrix.image }} ssl=${{ matrix.ssl }}
+    needs: frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ["almalinux:9", "almalinux:10", "ubuntu:24.04"]
+        ssl: ["false", "true"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - name: Run install test
+        run: bash scripts/ci-install-test.sh "${{ matrix.image }}" "${{ matrix.ssl }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,19 @@ The best thing about Open Source software is you can fix it yourself and contrib
 7. Push your changes to your forked repository.
 8. Open a pull request **into `main`**.
 
+### Testing Your Change
+
+Every pull request runs `install.sh` end to end on AlmaLinux 9, AlmaLinux 10 and Ubuntu 24.04, with and without SSL (see `.github/workflows/ci.yml`). You can run the same check locally before you push — all you need is Docker or Podman and a built frontend:
+
+```bash
+cd frontend && npm ci && npm run build && cd ..
+
+scripts/ci-install-test.sh almalinux:10 false   # <image> <ssl: true|false>
+scripts/ci-install-test.sh ubuntu:24.04 true
+```
+
+Each run starts a throwaway systemd container, installs the GUI from your working tree with `install.sh -c`, and checks that the service comes up, `/health` answers and the admin login works. It takes about a minute and prints `OK:` at the end; on failure it shows the tail of the installer log (or the service journal) so you can see what went wrong. The container is removed afterwards. The script uses Docker if it is installed and Podman otherwise; set `CONTAINER_ENGINE=podman` (or `docker`) to choose.
+
 We will review the PR and merge it as soon as possible. It's that simple!
 
 **Current stable:** **3.12.0** ([Releases](https://github.com/cvquesty/openvox-gui/releases)). See [docs/STATUS.md](docs/STATUS.md) and the version badge on the [README](README.md). Report bugs with the version from the GUI footer or `curl -k https://your-server:4567/api/health`.

--- a/scripts/ci-install-test.sh
+++ b/scripts/ci-install-test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Run install.sh end to end in a throwaway systemd container and check the
+# result. Shared by CI (.github/workflows/ci.yml) and local runs:
+#
+#   scripts/ci-install-test.sh almalinux:9   false
+#   scripts/ci-install-test.sh almalinux:10  true
+#   scripts/ci-install-test.sh ubuntu:24.04  false
+#
+# Needs Docker or Podman (CONTAINER_ENGINE=podman to force one; otherwise
+# docker is used if installed, else podman) and a pre-built frontend/dist
+# (npm run build) in the checkout; the installer runs with
+# BUILD_FRONTEND=false so Node.js is not needed in the container. Asserts:
+# install.sh exits 0, the service is active, /health answers on the
+# configured scheme, and the admin login returns 200.
+set -euo pipefail
+
+IMAGE="${1:?usage: ci-install-test.sh <image> <ssl: true|false>}"
+SSL="${2:?usage: ci-install-test.sh <image> <ssl: true|false>}"
+case "$SSL" in true|false) ;; *) echo "ssl must be true or false" >&2; exit 2 ;; esac
+
+ENGINE="${CONTAINER_ENGINE:-}"
+if [ -z "$ENGINE" ]; then
+  if command -v docker >/dev/null 2>&1; then ENGINE=docker
+  elif command -v podman >/dev/null 2>&1; then ENGINE=podman
+  else echo "neither docker nor podman found" >&2; exit 2
+  fi
+fi
+
+# Short names such as almalinux:10 resolve on Docker Hub. Podman hosts with
+# several unqualified-search-registries would otherwise prompt for one.
+case "$IMAGE" in */*) PULL_IMAGE="$IMAGE" ;; *) PULL_IMAGE="docker.io/library/$IMAGE" ;; esac
+"$ENGINE" pull -q "$PULL_IMAGE" >/dev/null
+
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+[ -f "$REPO/frontend/dist/index.html" ] || { echo "frontend/dist missing — run 'npm run build' in frontend/ first" >&2; exit 2; }
+
+NAME="ovoxgui-install-$$"
+FQDN="gui-test.example.com"
+STAGE=$(mktemp -d)
+cleanup() { "$ENGINE" rm -f "$NAME" >/dev/null 2>&1 || true; rm -rf "$STAGE"; }
+trap cleanup EXIT
+
+# The installer copies the whole checkout (cp -a), so stage it without
+# node_modules and .git to keep the copy small.
+tar -C "$REPO" --exclude=./.git --exclude=./frontend/node_modules --exclude=./build -cf - . | tar -C "$STAGE" -xf -
+
+case "$IMAGE" in
+  ubuntu:*)
+    # Stock ubuntu images ship no systemd; bake a minimal init layer.
+    RUN_IMAGE="openvox-gui-install-test-$(echo "$IMAGE" | tr ':.' '--')"
+    printf 'FROM %s\nENV DEBIAN_FRONTEND=noninteractive\nRUN apt-get update -qq && apt-get install -y -qq systemd systemd-sysv sudo curl openssl python3 python3-venv >/dev/null && apt-get clean\nCMD ["/lib/systemd/systemd"]\n' "$PULL_IMAGE" \
+      | "$ENGINE" build -q -t "$RUN_IMAGE" - >/dev/null
+    INIT=""
+    PREP="true"
+    PYTHON_BIN="/usr/bin/python3"
+    ;;
+  *)
+    RUN_IMAGE="$PULL_IMAGE"
+    INIT="/sbin/init"
+    # hostname: 'hostname -f' is used throughout install.sh and is not in
+    # the minimal EL images. python3.12: EL9's default python3 is 3.9.
+    # curl: EL9 images ship curl-minimal, which conflicts with the curl
+    # package, so only install it where no curl binary exists.
+    PREP="dnf install -y -q sudo openssl diffutils hostname python3.12 >/dev/null; command -v curl >/dev/null || dnf install -y -q curl >/dev/null"
+    PYTHON_BIN="/usr/bin/python3.12"
+    ;;
+esac
+
+"$ENGINE" run -d --privileged --name "$NAME" --hostname "$FQDN" \
+  -v "$STAGE":/src:ro "$RUN_IMAGE" $INIT >/dev/null
+sleep 5
+
+SCHEME=http
+[ "$SSL" = true ] && SCHEME=https
+
+"$ENGINE" exec "$NAME" bash -euo pipefail -c "
+  $PREP
+  cp -a /src /root/src
+
+  cat > /root/install.conf <<CONF
+APP_HOST=0.0.0.0
+PYTHON_BIN=${PYTHON_BIN}
+AUTH_BACKEND=local
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=ci-install-secret
+SSL_ENABLED=${SSL}
+SSL_CERT_PATH=/etc/openvox-gui-ci.crt
+SSL_KEY_PATH=/etc/openvox-gui-ci.key
+BUILD_FRONTEND=false
+INSTALL_NODEJS=false
+CONFIGURE_FIREWALL=false
+CONFIGURE_SELINUX=false
+CONFIGURE_PKG_REPO=false
+CONFIGURE_BOLT=false
+CONFIGURE_ENC=false
+CONF
+  if [ '${SSL}' = true ]; then
+    openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj '/CN=${FQDN}' \
+      -keyout /etc/openvox-gui-ci.key -out /etc/openvox-gui-ci.crt 2>/dev/null
+    chmod 644 /etc/openvox-gui-ci.key
+  fi
+
+  cd /root/src
+  bash install.sh -c /root/install.conf > /root/install.log 2>&1 \
+    || { echo 'FAIL: install.sh exited non-zero'; tail -n 40 /root/install.log; exit 1; }
+  echo 'PASS: install.sh exit 0'
+
+  [ \"\$(systemctl is-active openvox-gui)\" = active ] \
+    || { echo 'FAIL: service not active'; journalctl -u openvox-gui -n 40 --no-pager; exit 1; }
+  curl -skf ${SCHEME}://127.0.0.1:4567/health | grep -q '\"status\":\"ok\"' \
+    || { echo 'FAIL: /health on ${SCHEME}'; exit 1; }
+  echo 'PASS: service active, /health ok on ${SCHEME}'
+
+  CODE=\$(curl -sk -X POST ${SCHEME}://127.0.0.1:4567/api/auth/login \
+    -H 'Content-Type: application/json' \
+    -d '{\"username\":\"admin\",\"password\":\"ci-install-secret\"}' \
+    -o /dev/null -w '%{http_code}')
+  [ \"\$CODE\" = 200 ] || { echo \"FAIL: admin login returned \$CODE\"; exit 1; }
+  echo 'PASS: admin login'
+"
+echo "OK: install.sh on ${IMAGE} (SSL_ENABLED=${SSL}, ${ENGINE})"


### PR DESCRIPTION
First job from #48. `scripts/ci-install-test.sh` starts a privileged systemd container (`almalinux:9`, `almalinux:10` or `ubuntu:24.04`) with Docker or Podman, runs `install.sh -c` unattended with `BUILD_FRONTEND=false` and firewall/SELinux/package mirror/Bolt/ENC off, and asserts the installer exits 0, the service is active, `/health` answers on the configured scheme and the admin login returns 200. `SSL_ENABLED=true` legs use a self-signed cert for the container's FQDN. The same script runs locally; CONTRIBUTING.md explains how.

`.github/workflows/ci.yml` builds the frontend once and runs the script over the image × ssl matrix on pull requests and pushes to `main`; about a minute per leg, no secrets.

Depends on #46 and #47: on `main` as it stands #45 stops every leg at Step 8 and #44 fails every SSL leg, so this should merge after those two. With them applied the matrix is green (verified on GitHub runners from my fork); against unfixed `main` the harness fails exactly where #45 reported (`chown: invalid user: 'puppet:puppet'`).

Part of #48.

Assisted by: Claude Code